### PR TITLE
feat: multiple data overlay sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .yarn-integrity
 
 # Mock data
-data/
+neo4j/
+dataOverlay/
 
 # temp import data
 **/*.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # Yarn Integrity file
 .yarn-integrity
 
-# Mock data
+# Data output
 neo4j/
 dataOverlay/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Data generator for neo4j
-
-
+# Data generator for Metabolic Atlas
 
 ## Prerequisites
 
@@ -20,10 +18,13 @@ and then by
     $ yarn start <PATH TO DATA FILES>
 
 
-After that, a folder `data/` will be created under the current directory. This
-folder `data/` contains CSV files along with the [Cypher](https://neo4j.com/developer/cypher/) instructions to import
-the data. `<PATH TO DATA FILES>` should point to data files from this
-[repository](https://github.com/MetabolicAtlas/data-files).
+After that, the folders `neo4j` and `dataOverlay` will be created under the current directory.
+
+The folder `neo4j` contains CSV files along with the [Cypher](https://neo4j.com/developer/cypher/) instructions to import the data.
+
+The folder `dataOverlay` contains TSV and JSON files that can be served directly in [Metabolic Atlas](https://github.com/MetabolicAtlas/MetabolicAtlas).
+
+`<PATH TO DATA FILES>` should point to data files from this [repository](https://github.com/MetabolicAtlas/data-files).
 
 Please note that while the aforementioned commands can be run on their own, the
 output is meaningful only for the deployment pipeline of [Metabolic Atlas](https://github.com/MetabolicAtlas/MetabolicAtlas).

--- a/dataOverlay.js
+++ b/dataOverlay.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_TYPE_COMPONENTS = {
+  transcriptomics: 'gene',
+  metabolomics: 'compartmentalizedMetabolite',
+};
+
+const processDataOverlayFiles = ({ modelDir, componentIdDict }) => {
+  const filesDir = `${modelDir}/dataOverlay`;
+  if (!fs.existsSync(filesDir)) {
+    return;
+  }
+
+  const dataOverlayFiles = {};
+  const dataTypes = fs
+    .readdirSync(filesDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+
+  const dataSourcesDict = dataTypes.reduce(
+    (obj, dt) => ({
+      ...obj,
+      [dt]: parseIndexFile(
+        fs.readFileSync(`${filesDir}/${dt}/index.tsv`, 'utf8'),
+      ),
+    }),
+    {},
+  );
+
+  // TODO: write dataSourcesDict to data folder
+
+  for (const [dt, metadataList] of Object.entries(dataSourcesDict)) {
+    const componentType = DATA_TYPE_COMPONENTS[dt];
+    const componentIdSet = new Set(Object.keys(componentIdDict[componentType]));
+
+    for (const { filename } of metadataList) {
+      const inputFile = fs.readFileSync(
+        `${filesDir}/${dt}/${filename}`,
+        'utf8',
+      );
+      const condensedFile = condenseDataSourceFile({
+        inputFile,
+        componentIdSet,
+      });
+      // TODO: write condensedFile to data folder
+      console.log(condensedFile);
+    }
+  }
+};
+
+const parseIndexFile = (indexFile) => {
+  const dataSources = [];
+  const [header, ...rows] = indexFile.split('\n').filter(Boolean);
+  const keys = header.trim().split('\t').filter(Boolean);
+
+  return rows.map((row) =>
+    keys.reduce(
+      (obj, key) => ({
+        ...obj,
+        [key]: row.trim().split('\t').filter(Boolean)[keys.indexOf(key)],
+      }),
+      {},
+    ),
+  );
+};
+
+const condenseDataSourceFile = ({ inputFile, componentIdSet }) => {
+  const [header, ...rows] = inputFile.split('\n').filter(Boolean);
+
+  const filteredRows = rows.filter((row) => {
+    const [id] = row.trim().split('\t').filter(Boolean);
+    return componentIdSet.has(id);
+  });
+
+  return [header, ...filteredRows];
+};
+
+module.exports = { processDataOverlayFiles };

--- a/dataOverlay.js
+++ b/dataOverlay.js
@@ -11,8 +11,8 @@ const DATA_TYPE_COMPONENTS = {
  * to be used in the Metabolic Atlas website.
  * Example:
  * `modelDir`: ../data-files/integrated-models/Human-GEM
- * output index file: ./data/dataOverlay/Human-GEM/index.json
- * output data source file: ./data/dataOverlay/Human-GEM/transcriptomics/protein1.mock.tsv
+ * output index file: ./dataOverlay/Human-GEM/index.json
+ * output data source file: ./dataOverlay/Human-GEM/transcriptomics/protein1.mock.tsv
  */
 const processDataOverlayFiles = ({ modelDir, outDir, componentIdDict }) => {
   const filesDir = `${modelDir}/dataOverlay`;
@@ -73,14 +73,12 @@ const processDataOverlayFiles = ({ modelDir, outDir, componentIdDict }) => {
 };
 
 const getModelOutDir = ({ modelDir, outDir }) => {
-  const dataOverlayOutDir = `${outDir}/dataOverlay`;
-
-  if (!fs.existsSync(`${dataOverlayOutDir}`)) {
-    fs.mkdirSync(`${dataOverlayOutDir}`);
+  if (!fs.existsSync(`${outDir}`)) {
+    fs.mkdirSync(`${outDir}`);
   }
 
   const modelFolder = modelDir.split('/').pop();
-  const modelOutDir = `${outDir}/dataOverlay/${modelFolder}`;
+  const modelOutDir = `${outDir}/${modelFolder}`;
   if (!fs.existsSync(`${modelOutDir}`)) {
     fs.mkdirSync(`${modelOutDir}`);
   }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const parser = require('./parser.js');
 const utils  = require('./utils.js');
 const writer = require('./writer.js');
 const cypher = require('./cypher.js');
+const { processDataOverlayFiles } = require('./dataOverlay');
 
 let extNodeIdTracker = 1;
 const humanGeneIdSet = new Set();
@@ -38,6 +39,8 @@ const parseModelFiles = (modelDir) => {
   if (isHuman) {
     utils.getHumanGeneIdSet(componentIdDict, humanGeneIdSet);
   }
+
+  processDataOverlayFiles({ modelDir, componentIdDict })
 
   // ========================================================================
   // SVG mapping file

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const parseModelFiles = (modelDir) => {
     utils.getHumanGeneIdSet(componentIdDict, humanGeneIdSet);
   }
 
-  processDataOverlayFiles({ modelDir, componentIdDict })
+  processDataOverlayFiles({ modelDir, outDir, componentIdDict });
 
   // ========================================================================
   // SVG mapping file

--- a/index.js
+++ b/index.js
@@ -13,8 +13,7 @@ let instructions = [];
 let dropIndexes = false;
 let prefix = '' ;
 let outputPath = '';
-let outDir = './data';
-
+let outDir = './neo4j';
 
 const parseModelFiles = (modelDir) => {
   // find the yaml in the folder
@@ -40,7 +39,7 @@ const parseModelFiles = (modelDir) => {
     utils.getHumanGeneIdSet(componentIdDict, humanGeneIdSet);
   }
 
-  processDataOverlayFiles({ modelDir, outDir, componentIdDict });
+  processDataOverlayFiles({ modelDir, outDir: './dataOverlay', componentIdDict });
 
   // ========================================================================
   // SVG mapping file

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "neo4j-data-generation",
+  "name": "data-generation",
   "version": "1.0.0",
-  "description": "Data generator for neo4j",
+  "description": "Data generator for Metabolic Atlas",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"


### PR DESCRIPTION
This is related to MetabolicAtlas/private-issues#113.

Most of the data overlay processing logic is encapsulated in a single file to try to keep the functionality of this repo more modular. For more info, please refer to the doc comment for the `processDataOverlayFiles` function.

For testing, please use [this branch from data-files](https://github.com/MetabolicAtlas/data-files/tree/feat/mock-data-overlay-sources). To validate that the data is correctly processed, make sure that the faulty rows mentioned in https://github.com/MetabolicAtlas/data-files/pull/14 are not included in the output.