### PR TITLE
feat: remove code to parse HPA json file that is not needed anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,6 +179,3 @@ try {
 // ========================================================================
 // write cypher intructions to file
 writer.writeCypherFile(instructions, outDir);
-
-// write a smaller version of the hpa rna levels file, to send to the frontend
-writer.writeHpaRnaJson(humanGeneIdSet, inputDir, outDir);

--- a/writer.js
+++ b/writer.js
@@ -175,25 +175,6 @@ const writeCypherFile = (instructions, outDir) => {
   fs.writeFileSync(`${outDir}/import.cypher`, instructions.join('\n'), 'utf8');
 }
 
-const writeHpaRnaJson = (humanGeneIdSet, inputDir, outDir) => {
-// write a smaller version of the hpa rna levels file, to send to the frontend
-// remove expressions of genes not in any human models parsed
-  if (!fs.existsSync(`${inputDir}/hpaRnaFull.json`)) {
-      throw new Error("HPA rna JSON file not found");
-  } else {
-    const hpaRnaExpressionJson = require(`${inputDir}/hpaRnaFull.json`);
-
-    Object.keys(hpaRnaExpressionJson.levels).forEach((geneId) => {
-      if (!humanGeneIdSet.has(geneId)) {
-        delete hpaRnaExpressionJson.levels[geneId];
-      }
-    });
-
-    const json_rna = JSON.stringify(hpaRnaExpressionJson);
-    fs.writeFileSync(`${outDir}/hpaRna.json`, json_rna);
-  }
-}
-
 module.exports = {
   writeComponentSvgCSV,
   writePMIDCSV,
@@ -211,5 +192,4 @@ module.exports = {
   writeComponentCSV,
   writeComponentStateCSV,
   writeCypherFile,
-  writeHpaRnaJson,
 }


### PR DESCRIPTION
This PR together with [PR 18](https://github.com/MetabolicAtlas/data-files/pull/18) and [PR 699](https://github.com/MetabolicAtlas/MetabolicAtlas/pull/699) closes [#124](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/124)

Since the HPA data for DataOverlay will be provided as the transcriptomics tsv file for Human-GEM, the parsing code in data-generation is no longer needed.