### PR TITLE
fix: pass argument metadataSection to getComponentSvgRel

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ const parseModelFiles = (modelDir) => {
       component,
       svgNodes,
       modelDir,
+      metadataSection
     );
     writer.writeComponentSvgCSV(svgRels, outputPath, component);
   });

--- a/parser.js
+++ b/parser.js
@@ -26,7 +26,7 @@ const getInfoFromYaml = (yamlFile) => {
   ];
 };
 
-const getComponentSvgRel = (content, component, svgNodes, modelDir) => {
+const getComponentSvgRel = (content, component, svgNodes, modelDir, metadataSection) => {
   // get SVG files for compartments and subsystems
   const filename = `${component}SVG.tsv`;
   const mappingFile = utils.getFile(modelDir, filename);


### PR DESCRIPTION
This PR closes #30 

This bug was found when I was working on the issue https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/metabolicatlas/970

I created this PR out of the routine because this bug fix is required to manual modification of model files during updating of model versions. 

**Testing**
In order to test the bug, you will need to use the branch `test/undefined-metadataSection-on-missing-map ` for the repo `data-files`

Then in the repo `data-generation`
In this branch `fix/undefined-metadataSection`, when running 
```
./generate
```
You will get this error message
```
Error: subsystem "sce00040  Pentose and glucuronate interconversions" does not exist in the model "Yeast-GEM"
```
Which indicates the SVG map for the subsystem "sce00040" is missing from the model

However, when running the same command in the `main` branch. 
You only get 
```
ReferenceError: metadataSection is not defined
```

